### PR TITLE
物理OFFフラグが維持されるようにする

### DIFF
--- a/VMD.cc
+++ b/VMD.cc
@@ -296,22 +296,24 @@ void VMD_Frame::set_interpolation_y(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t 
 void VMD_Frame::set_interpolation_z(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2)
 {
   uint8_t* ip = interpolation;
+  uint8_t physicsDisabled_lower = ip[2];
   ip[ 2] = ip[17] = ip[32] = x1; // Z_x1
   ip[ 6] = ip[21] = ip[36] = ip[51] = y1; // Z_y1
   ip[10] = ip[25] = ip[40] = ip[55] = x2; // Z_x2
   ip[14] = ip[29] = ip[44] = ip[59] = y2; // Z_y2
 
-  ip[2] = 0; // MMD 9.31では0になっている
+  ip[2] = physicsDisabled_lower; // MMD 9.31では物理OFFフラグ（下位バイト）
 }
 
 void VMD_Frame::set_interpolation_r(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2)
 {
   uint8_t* ip = interpolation;
+  uint8_t physicsDisabled_upper = ip[3];
   ip[ 3] = ip[18] = ip[33] = ip[48] = x1; // R_x1
   ip[ 7] = ip[22] = ip[37] = ip[52] = y1; // R_y1
   ip[11] = ip[26] = ip[41] = ip[56] = x2; // R_x2
   ip[15] = ip[30] = ip[45] = ip[60] = y2; // R_y2
 
-  ip[3] = 0; // MMD 9.31では0になっている
+  ip[3] = physicsDisabled_upper; // MMD 9.31では物理OFFフラグ（上位バイト）
 }
 

--- a/interpolate.cc
+++ b/interpolate.cc
@@ -50,6 +50,8 @@ VMD_Frame make_intermediate_frame(const VMD_Frame& head_frame, const VMD_Frame& 
 {
   VMD_Frame f;
   memcpy(f.bonename, head_frame.bonename, f.bonename_len);
+  f.interpolation[2] = head_frame.interpolation[2];
+  f.interpolation[3] = head_frame.interpolation[3];
   if (bezier) {
     // ベジェ曲線補間
     const uint8_t* ip = tail_frame.interpolation;


### PR DESCRIPTION
・背景
　`--bezier`をONにして実行すると、物理影響ボーンの物理OFFフラグの設定が変わってしまう。
　具体的には、もともと物理OFFのキーフレームがあった区間においても、物理ONのキーフレームが出力されてしまう。

・目的
　物理焼き込みモーションの軽量化目的で利用する場合の利便性のために、物理OFFフラグが維持されるようにしたい。

・原因
　`set_interpolation_z`および`set_interpolation_r`メソッドで、物理OFFフラグの領域が0（物理ON）で上書きされている。

・対策
　もともと設定されていた物理OFFフラグの値を退避しておき、書き戻すようにする。

（補足）
補間曲線の記録領域64バイトのうち、MMDが認識するのは4nバイト目（最初のバイトを0とする）のみである。
残りの領域のうち、2バイト目と3バイト目が物理OFFフラグの領域として使われている。
物理OFFフラグのフォーマットは16ビット整数（リトルエンディアン）であり、0が物理ON、3939（10進）が物理OFFを表す。
`set_interpolation_z`および`set_interpolation_r`メソッドでは物理OFFフラグの領域に常に0が書き込まれる。
そのため、当該メソッドが適用されたキーフレームは全て物理ONとなってしまう。
もともと物理OFFフラグの領域に入っていた値を書き戻すようにすることで、物理OFFフラグが維持される。

物理焼き込みモーションが物理ONになると、MMDで読み込んだ際に、焼き込んだ通りの姿勢が得られなくなってしまう。
期待する結果を得るには、当該モーションを読み込んだ際に「物理ON/OFFフレーム変換」を実施する必要があった。
物理OFFフラグが維持されるようになることにより、この手順を省くことができる。